### PR TITLE
IDC-7 Setup nexus repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 		mavenLocal()
 
 		maven {
-			url "https://cdn.lfrs.sl/repository.liferay.com/nexus/content/groups/public"
+			url "http://nexus-wcm.liferay.org.es/repository/dxp"
 		}
 	}
 }

--- a/campaign-manager-api/build.gradle
+++ b/campaign-manager-api/build.gradle
@@ -8,3 +8,11 @@ dependencies {
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 }
+
+repositories {
+	mavenLocal()
+
+	maven {
+		url "http://nexus-wcm.liferay.org.es/repository/dxp"
+	}
+}

--- a/campaign-manager-service/build.gradle
+++ b/campaign-manager-service/build.gradle
@@ -25,3 +25,11 @@ dependencies {
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	provided project(":campaign-manager-api")
 }
+
+repositories {
+	mavenLocal()
+
+	maven {
+		url "http://nexus-wcm.liferay.org.es/repository/dxp"
+	}
+}

--- a/campaign-manager-test/build.gradle
+++ b/campaign-manager-test/build.gradle
@@ -15,3 +15,11 @@ dependencies {
 	testIntegrationCompile project(":campaign-manager-api")
 	testIntegrationCompile project(":campaign-manager-service")
 }
+
+repositories {
+	mavenLocal()
+
+	maven {
+		url "http://nexus-wcm.liferay.org.es/repository/dxp"
+	}
+}

--- a/campaign-manager-web/build.gradle
+++ b/campaign-manager-web/build.gradle
@@ -14,3 +14,11 @@ dependencies {
 	provided project(":campaign-manager-api")
 	provided project(":campaign-manager-service")
 }
+
+repositories {
+	mavenLocal()
+
+	maven {
+		url "http://nexus-wcm.liferay.org.es/repository/dxp"
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
 		mavenLocal()
 
 		maven {
-			url "https://cdn.lfrs.sl/repository.liferay.com/nexus/content/groups/public"
+			url "http://nexus-wcm.liferay.org.es/repository/dxp"
 		}
 
 		mavenCentral()


### PR DESCRIPTION
With these changes libraries are consumed from the nexus-wcm.liferay.org.es/repository/dxp repository. 

To publish new libraries to the CM repository, use

```
gradle uploadArchives -Psonatype.release.url=http://nexus-wcm.liferay.org.es/repository/cm -Psonatype.release.username=[user] -Psonatype.release.password=[password]
```

for releases and 

```
gradle uploadArchives -Psonatype.snapshot.url=http://nexus-wcm.liferay.org.es/repository/cm-snapshot -Psonatype.snapshot.username=[user] -Psonatype.snapshot.password=[password]
```

for snapshots.
